### PR TITLE
Add half-integer Winger3j symbol support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,9 @@ mod rational;
 
 mod wigner_3j;
 pub use self::wigner_3j::{wigner_3j, clebsch_gordan, clear_wigner_3j_cache};
+mod wigner_3j_half_integer;
+pub use self::wigner_3j_half_integer::{
+    wigner_3j_half_integer,
+    clebsch_gordan_half_integer,
+    clear_wigner_3j_cache_half_integer,
+};

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -1,6 +1,11 @@
 use std::borrow::Borrow;
 
 use crate::primes::PrimeFactorization;
+use crate::primes::factorial;
+
+lazy_static::lazy_static!(
+    static ref SQRT_PI_F64: f64 = (std::f64::consts::PI).sqrt();
+);
 
 /// A rational number represented as two integer prime factorizations, one for
 /// numerator and one for denominator. The sign of the fraction is stored in the
@@ -9,6 +14,7 @@ use crate::primes::PrimeFactorization;
 pub struct Rational {
     pub numerator: PrimeFactorization,
     pub denominator: PrimeFactorization,
+    pub sqrt_pi: i32,
 }
 
 impl Rational {
@@ -19,6 +25,7 @@ impl Rational {
         return Rational {
             numerator,
             denominator,
+            sqrt_pi: 0,
         };
     }
 
@@ -37,7 +44,7 @@ impl Rational {
 
     /// Get the value of this `Rational` as a floating point value
     pub fn as_f64(&self) -> f64 {
-        self.numerator.as_f64() / self.denominator.as_f64()
+        self.numerator.as_f64() / self.denominator.as_f64() * SQRT_PI_F64.powi(self.sqrt_pi)
     }
 
     /// Get the signed root of this `Rational`, i.e. `sign(R) * sqrt(|R|)` where
@@ -58,5 +65,110 @@ impl<T> std::ops::MulAssign<T> for Rational where T: Borrow<Rational> {
 
         self.numerator *= &rhs.numerator;
         self.denominator *= &rhs.denominator;
+        self.sqrt_pi += &rhs.sqrt_pi;
+    }
+}
+
+impl std::ops::Mul for Rational {
+    type Output = Rational;
+    fn mul(mut self, rhs: Self) -> Self::Output {
+        self *= &rhs;
+        return self;
+    }
+}
+
+
+impl<T> std::ops::DivAssign<T> for Rational where T: Borrow<Rational> {
+    fn div_assign(&mut self, rhs: T) {
+        let rhs = rhs.borrow();
+        debug_assert_eq!(self.denominator.sign, 1);
+        debug_assert_eq!(rhs.denominator.sign, 1);
+
+        self.numerator.sign *= rhs.numerator.sign;
+
+        self.numerator *= &rhs.denominator;
+        self.denominator *= &rhs.numerator;
+        self.denominator.sign = 1;
+        self.sqrt_pi -= &rhs.sqrt_pi;
+    }
+}
+
+impl std::ops::Div for Rational {
+    type Output = Rational;
+    fn div(mut self, rhs: Self) -> Self::Output {
+        self /= &rhs;
+        return self;
+    }
+}
+
+
+/// Factorials of half-integer can be calculated by Gamma function,
+/// ```text
+/// n! = Gamma(n+1)
+/// (n-1/2)! = Gamma(n-1+1+1/2) = Gamma(n+1/2) = (2n)! / (2^2n * n!) * sqrt(pi)
+/// ```
+pub fn factorial_half_integer(double_n: u32) -> Rational {
+    if double_n % 2 == 0 {
+        let n = double_n / 2;
+        return Rational {
+            numerator: factorial(n),
+            denominator: PrimeFactorization::one(),
+            sqrt_pi: 0,
+        }
+    }
+
+    let n = double_n / 2 + 1;   // evaluate (n-1/2)!
+    let numerator = factorial(2*n);           // (2n)!
+    let mut denominator = factorial(n);       // n!
+    if denominator.factors.is_empty() {
+        denominator.factors.push(2 * (n as u16)); // special case for (1/2)!
+    } else {
+        denominator.factors[0] += 2 * (n as u16); // 2^2n
+    }
+
+    let mut ret = Rational {
+        numerator,
+        denominator,
+        sqrt_pi: 1,
+    };
+    ret.simplify();
+    return ret;
+}
+
+
+#[cfg(test)]
+#[allow(clippy::redundant_clone)]
+mod tests{
+    use super::*;
+
+    use approx::assert_ulps_eq;
+
+    #[test]
+    fn test_factorial_half_integer() {
+        // integer case
+        let n = 8;
+        let ret = factorial_half_integer(n);
+        let expect = factorial(n/2);
+        assert_eq!(ret.numerator, expect);
+        assert_eq!(ret.denominator, PrimeFactorization::one());
+        assert_eq!(ret.sqrt_pi, 0);
+
+        // half integer case, (1/2)! = sqrt_pi * 1/2
+        let n = 1;
+        let ret = factorial_half_integer(n).as_f64();
+        let expect = *SQRT_PI_F64 / 2.0;
+        assert_ulps_eq!(ret, expect);
+
+        // half integer case, (3/2)! = sqrt_pi * 1/2 * 3/2 = sqrt_pi * 3 / 4
+        let n = 3;
+        let ret = factorial_half_integer(n).as_f64();
+        let expect = *SQRT_PI_F64 * 3.0 / 4.0;
+        assert_ulps_eq!(ret, expect);
+
+        // half integer case, (3/2)! = sqrt_pi * 1/2 * 3/2 * 5/2 = sqrt_pi * 15 / 8
+        let n = 5;
+        let ret = factorial_half_integer(n).as_f64();
+        let expect = *SQRT_PI_F64 * 15.0 / 8.0;
+        assert_ulps_eq!(ret, expect);
     }
 }

--- a/src/wigner_3j.rs
+++ b/src/wigner_3j.rs
@@ -168,7 +168,7 @@ pub(crate) fn triangle_condition(j1: u32, j2: u32, j3: u32) -> bool {
 }
 
 // reorder j1/m1, j2/m2, j3/m3 such that j1 >= j2 >= j3 and m1 >= 0 or m1 == 0 && m2 >= 0
-pub(crate) fn reorder3j(j1: u32, j2: u32, j3: u32, m1: i32, m2: i32, m3: i32, mut sign: f64) -> (u32, u32, u32, i32, i32, i32, f64) {
+fn reorder3j(j1: u32, j2: u32, j3: u32, m1: i32, m2: i32, m3: i32, mut sign: f64) -> (u32, u32, u32, i32, i32, i32, f64) {
     if j1 < j2 {
         return reorder3j(j2, j1, j3, m2, m1, m3, -sign);
     } else if j2 < j3 {

--- a/src/wigner_3j.rs
+++ b/src/wigner_3j.rs
@@ -163,12 +163,12 @@ pub unsafe extern "C" fn clebsch_gordan_array_c(j1: u32, j2: u32, j3: u32, data:
 }
 
 /// check the triangle condition on j1, j2, j3, i.e. `|j1 - j2| <= j3 <= j1 + j2`
-fn triangle_condition(j1: u32, j2: u32, j3: u32) -> bool {
+pub(crate) fn triangle_condition(j1: u32, j2: u32, j3: u32) -> bool {
     return (j3 <= j1 + j2) && (j1 <= j2 + j3) && (j2 <= j3 + j1);
 }
 
 // reorder j1/m1, j2/m2, j3/m3 such that j1 >= j2 >= j3 and m1 >= 0 or m1 == 0 && m2 >= 0
-fn reorder3j(j1: u32, j2: u32, j3: u32, m1: i32, m2: i32, m3: i32, mut sign: f64) -> (u32, u32, u32, i32, i32, i32, f64) {
+pub(crate) fn reorder3j(j1: u32, j2: u32, j3: u32, m1: i32, m2: i32, m3: i32, mut sign: f64) -> (u32, u32, u32, i32, i32, i32, f64) {
     if j1 < j2 {
         return reorder3j(j2, j1, j3, m2, m1, m3, -sign);
     } else if j2 < j3 {
@@ -196,16 +196,16 @@ fn triangle_coefficient(j1: u32, j2: u32, j3: u32) -> Rational {
     return result;
 }
 
-fn max(a: i32, b: i32, c: i32) -> i32 {
+pub(crate) fn max(a: i32, b: i32, c: i32) -> i32 {
     std::cmp::max(a, std::cmp::max(b, c))
 }
 
-fn min(a: i32, b: i32, c: i32) -> i32 {
+pub(crate) fn min(a: i32, b: i32, c: i32) -> i32 {
     std::cmp::min(a, std::cmp::min(b, c))
 }
 
 /// compute the sum appearing in the 3j symbol
-fn compute_3j_series(total_j: u32, beta1: i32, beta2: i32, beta3: i32, alpha1: i32, alpha2: i32) -> (f64, PrimeFactorization) {
+pub(crate) fn compute_3j_series(total_j: u32, beta1: i32, beta2: i32, beta3: i32, alpha1: i32, alpha2: i32) -> (f64, PrimeFactorization) {
     let range = max(alpha1, alpha2, 0)..(min(beta1, beta2, beta3) + 1);
 
     let mut numerators = Vec::with_capacity(range.len());
@@ -263,7 +263,7 @@ fn compute_3j_series(total_j: u32, beta1: i32, beta2: i32, beta3: i32, alpha1: i
 /// Given a list of numerators and denominators, compute the common denominator
 /// and the rescaled numerator, putting all fractions at the same common
 /// denominator
-fn common_denominator(
+pub(crate) fn common_denominator(
     numerators: &mut [PrimeFactorization],
     denominators: &[PrimeFactorization]
 ) -> PrimeFactorization {

--- a/src/wigner_3j_half_integer.rs
+++ b/src/wigner_3j_half_integer.rs
@@ -1,0 +1,225 @@
+use std::num::NonZeroUsize;
+
+use parking_lot::Mutex;
+
+use lru::LruCache;
+use rayon::prelude::*;
+
+use crate::primes::{factorial, PrimeFactorization};
+use crate::rational::{factorial_half_integer, Rational};
+use crate::wigner_3j::{
+    triangle_condition,
+    reorder3j,
+    compute_3j_series,
+};
+
+
+// cache up to that many wigner_3j symbols in a LRU cache. 200_000 entries is
+// enough for our use case of computing all symbols up to `j_{1, 2, 3}=20`
+const WIGNER_3J_CACHE_SIZE: usize = 200_000;
+
+type Wigner3jCacheKey = (i32, i32, i32, i32, i32);
+lazy_static::lazy_static!(
+    static ref CACHED_WIGNER_3J: Mutex<LruCache<Wigner3jCacheKey, f64>> = Mutex::new(
+        LruCache::new(NonZeroUsize::new(WIGNER_3J_CACHE_SIZE).expect("cache size is zero"))
+    );
+);
+
+#[no_mangle]
+pub extern "C" fn clear_wigner_3j_cache_half_integer() {
+    CACHED_WIGNER_3J.lock().clear();
+}
+
+/// Compute the Wigner 3j coefficient for the given `j1`, `j2`, `j2`, `m1`,
+/// `m2`, `m3`.
+#[no_mangle]
+pub extern "C" fn wigner_3j_half_integer(j1: u32, j2: u32, j3: u32, m1: i32, m2: i32, m3: i32) -> f64 {
+    if m1.unsigned_abs() > j1 {
+        panic!("invalid j1/m1 in wigner3j: {}/{}", j1, m1);
+    } else if m2.unsigned_abs() > j2 {
+        panic!("invalid j2/m2 in wigner3j: {}/{}", j2, m2);
+    } else if m3.unsigned_abs() > j3 {
+        panic!("invalid j3/m3 in wigner3j: {}/{}", j3, m3);
+    }
+
+    if !triangle_condition(j1, j2, j3) || m1 + m2 + m3 != 0 {
+        return 0.0;
+    }
+
+    let (j1, j2, j3, m1, m2, _, mut sign) = reorder3j(j1, j2, j3, m1, m2, m3, 1.0);
+
+    let total_j = j1 + j2 + j3;
+
+    // according to https://github.com/Jutho/WignerSymbols.jl/blob/master/src/WignerSymbols.jl#L93-L97
+    // alpha1, alpha2, beta1, beta2, beta3 are guranteed to be integers
+    let alpha1 = j2 as i32 - m1 - j3 as i32;
+    assert_eq!(alpha1 % 2, 0);
+    let alpha1 = alpha1 / 2;
+
+    let alpha2 = j1 as i32 + m2 - j3 as i32;
+    assert_eq!(alpha2 % 2, 0);
+    let alpha2 = alpha2 / 2;
+
+    let beta1 = (j1 + j2 - j3) as i32;
+    assert_eq!(beta1 % 2, 0);
+    let beta1 = beta1 / 2;
+
+    let beta2 = j1 as i32 - m1;
+    assert_eq!(beta2 % 2, 0);
+    let beta2 = beta2 / 2;
+
+    let beta3 = j2 as i32 + m2;
+    assert_eq!(beta3 % 2, 0);
+    let beta3 = beta3 / 2;
+
+
+    // extra sign in definition: alpha1 - alpha2 = j1 + m2 - j2 + m1 = j1 - j2 + m3
+    if (alpha1 - alpha2) % 2 != 0 {
+        sign = -sign;
+    }
+
+    {
+        let mut cache = CACHED_WIGNER_3J.lock();
+        if let Some(&cached_value) = cache.get(&(alpha1, alpha2, beta1, beta2, beta3)) {
+            return sign * cached_value;
+        }
+    }
+
+    let s1 = triangle_coefficient_half_integer(j1, j2, j3);
+
+    debug_assert!(beta2 >= 0);
+    let mut s2 = factorial(beta2 as u32);
+
+    debug_assert!((beta1 - alpha1) >= 0);
+    s2 *= factorial((beta1 - alpha1) as u32);
+
+    debug_assert!((beta1 - alpha2) >= 0);
+    s2 *= factorial((beta1 - alpha2) as u32);
+
+    debug_assert!(beta3 >= 0);
+    s2 *= factorial(beta3 as u32);
+
+    debug_assert!((beta3 - alpha1) >= 0);
+    s2 *= factorial((beta3 - alpha1) as u32);
+
+    debug_assert!((beta2 - alpha2) >= 0);
+    s2 *= factorial((beta2 - alpha2) as u32);
+
+    let (series_numerator, series_denominator) = compute_3j_series(total_j/2, beta1, beta2, beta3, alpha1, alpha2);
+
+    let mut s = Rational::new(s1.numerator * s2, s1.denominator);
+
+    let series_denominator = Rational::new(PrimeFactorization::one(), series_denominator);
+
+    // insert series denominator in the root, this improves precision compared
+    // to immediately converting the full series to f64
+    s *= &series_denominator;
+    s *= &series_denominator;
+    s.simplify();
+
+    let result = series_numerator * s.signed_root();
+
+    {
+        let mut cache = CACHED_WIGNER_3J.lock();
+        cache.put((alpha1, alpha2, beta1, beta2, beta3), result);
+    }
+
+    return sign * result;
+}
+
+/// Compute the Clebsch-Gordan coefficient <j1 m1 ; j2 m2 | j3 m3> using their
+/// relation to Wigner 3j coefficients:
+///
+/// ```text
+/// <j1 m1 ; j2 m2 | j3 m3> = (-1)^(j1 - j2 + m3) sqrt(2*j3 + 1) wigner_3j(j1, j2, j3, m1, m2, -m3)
+/// ```
+#[no_mangle]
+pub extern "C" fn clebsch_gordan_half_integer(j1: u32, m1: i32, j2: u32, m2: i32, j3: u32, m3: i32) -> f64 {
+    let mut w3j = wigner_3j_half_integer(j1, j2, j3, m1, m2, -m3);
+
+    w3j *= f64::sqrt((j3 + 1) as f64);
+    if (j1 as i32 - j2 as i32 + m3) % 4 != 0 {
+        return -w3j;
+    } else {
+        return w3j;
+    }
+}
+
+
+/// Compute the full array of Clebsch-Gordan coefficients for the three given
+/// `j`.
+///
+/// Data will be written to `output`, which can be interpreted as a row-major
+/// 3-dimensional array with shape `(2 * j1 + 1, 2 * j2 + 1, 2 * j3 + 1)`.
+pub fn clebsch_gordan_array_half_integer(j1: u32, j2: u32, j3: u32, output: &mut [f64]) {
+    let j1_size = 2 * j1 + 1;
+    let j2_size = 2 * j2 + 1;
+    let j3_size = 2 * j3 + 1;
+
+    let size = (j1_size * j2_size * j3_size) as usize;
+    if output.len() != size {
+        panic!(
+            "invalid output size, expected to have space for {} entries, but got {}",
+            size, output.len()
+        );
+    }
+
+    output.par_iter_mut().enumerate().for_each(|(i, o)| {
+        let i = i as u32;
+        let m1 = ((i / j3_size) / j2_size) as i32 - j1 as i32;
+        let m2 = ((i / j3_size) % j2_size) as i32 - j2 as i32;
+        let m3 = (i % j3_size) as i32 - j3 as i32;
+
+        *o = clebsch_gordan_half_integer(j1, m1, j2, m2, j3, m3);
+    })
+}
+
+/// Same function as `clebsch_gordan_array`, but can be called directly from C
+#[no_mangle]
+pub unsafe extern "C" fn clebsch_gordan_array_c_half_integer(j1: u32, j2: u32, j3: u32, data: *mut f64, len: u64) {
+    let slice = std::slice::from_raw_parts_mut(data, len as usize);
+    clebsch_gordan_array_half_integer(j1, j2, j3, slice);
+}
+
+fn triangle_coefficient_half_integer(j1: u32, j2: u32, j3: u32) -> Rational {
+    let n1 = factorial_half_integer(j1 + j2 - j3);
+    let n2 = factorial_half_integer(j1 - j2 + j3);
+    let n3 = factorial_half_integer(j2 + j3 - j1);
+    let numerator = n1 * n2 * n3;
+    let denominator = factorial_half_integer(j1 + j2 + j3 + 2);
+
+    let mut result = numerator / denominator;
+    result.simplify();
+    return result;
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_ulps_eq;
+
+    #[test]
+    fn test_wigner3j_half_integer() {
+        // checked against sympy
+        assert_ulps_eq!(wigner_3j_half_integer(4, 12, 8, 0, 0, 2), 0.0);
+        assert_ulps_eq!(wigner_3j_half_integer(4, 12, 8, 0, 0, 0), f64::sqrt(715.0) / 143.0);
+        assert_ulps_eq!(wigner_3j_half_integer(10, 6, 4, -6, 6, 0), f64::sqrt(330.0) / 165.0);
+        assert_ulps_eq!(wigner_3j_half_integer(10, 6, 4, -4, 6, -2), -f64::sqrt(330.0) / 330.0);
+        assert_ulps_eq!(wigner_3j_half_integer(200, 200, 200, 200, -200, 0), 2.689688852311291e-13);
+
+        assert_ulps_eq!(wigner_3j_half_integer(0, 2, 2, 0, 0, 0), -0.5773502691896257);
+
+        // https://github.com/Luthaf/wigners/issues/7
+        assert_ulps_eq!(wigner_3j_half_integer(200, 600, 570, 4, -4, 0), 0.001979165708981953);
+    }
+
+    #[test]
+    fn test_clebsch_gordan_half_integer() {
+        // checked against sympy
+        assert_ulps_eq!(clebsch_gordan_half_integer(4, 0, 12, 0, 8, 2), 0.0);
+        assert_ulps_eq!(clebsch_gordan_half_integer(2, 2, 2, 2, 4, 4), 1.0);
+        assert_ulps_eq!(clebsch_gordan_half_integer(4, 4, 2, -2, 6, 2), f64::sqrt(1.0 / 15.0));
+    }
+}


### PR DESCRIPTION
I just added `wigner_3j_half_integer.rs` to support half-integer.

- Modified `rational.rs` to support half-integer factorial using Gamma function
  `(n-1/2)! = Gamma(n-1+1+1/2) = Gamma(n+1/2) = (2n)! / (2^2n * n!) * sqrt(pi)`.
- All the half-integers are represented as doubled value, i.e. `f_half_integer(1, 2, 3, 0, 0, 0) == f(1/2, 1, 3/2, 0, 0, 0)`

Tested with integer and half-integer arguments without failure.

I also have a question, do we need `panic!()` on invalid (j,m) pairs in `w3j`?  I came with this issue since half-integer functions require j±m is integer, which is a stronger requirement than integer functions. For now, I just let them return zero on invalid inputs, and if you have any suggestion, we can just fix it.